### PR TITLE
Exposed timestep variable

### DIFF
--- a/DIKUArcade/DIKUGame.cs
+++ b/DIKUArcade/DIKUGame.cs
@@ -1,6 +1,5 @@
 using System;
 using DIKUArcade.GUI;
-using DIKUArcade.Input;
 using DIKUArcade.Timers;
 
 namespace DIKUArcade {
@@ -10,6 +9,12 @@ namespace DIKUArcade {
     public abstract class DIKUGame {
         protected Window window;
         private GameTimer gameTimer;
+
+        /// <summary>
+        /// The exact amount of captured updates in the last second.
+        /// Can be used for framerate independent calculations.
+        /// </summary>
+        public static int Timestep { get; private set; }
 
         public DIKUGame(WindowArgs windowArgs) {
             window = new Window(windowArgs);
@@ -50,7 +55,7 @@ namespace DIKUArcade {
                     }
 
                     if (gameTimer.ShouldReset()) {
-
+                        Timestep = gameTimer.CapturedUpdates;
                     }
                 }
 

--- a/DIKUArcade/GUI/Window.cs
+++ b/DIKUArcade/GUI/Window.cs
@@ -227,7 +227,7 @@ namespace DIKUArcade.GUI {
         /// Close the underlying OpenTK window object.
         /// Do not call this method outside the engine.
         /// </summary>
-        public void DestroyWindow() {
+        internal void DestroyWindow() {
             window.Close();
             window.Dispose();
             window = null;


### PR DESCRIPTION
Expose the captured updates in a static variable.

Also made DestroyWindow() internal if it is not supposed to be used outside the engine.